### PR TITLE
PHP8: fixes passing null in `Mage_Adminhtml_Block_Customer_Edit_Tab_Wishlist_Grid_Renderer_Description::render()`

### DIFF
--- a/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Wishlist/Grid/Renderer/Description.php
+++ b/app/code/core/Mage/Adminhtml/Block/Customer/Edit/Tab/Wishlist/Grid/Renderer/Description.php
@@ -23,6 +23,7 @@ class Mage_Adminhtml_Block_Customer_Edit_Tab_Wishlist_Grid_Renderer_Description 
 {
     public function render(Varien_Object $row)
     {
-        return nl2br(htmlspecialchars($row->getData($this->getColumn()->getIndex())));
+        $value = $row->getData($this->getColumn()->getIndex());
+        return is_string($value) ? nl2br(htmlspecialchars($value)) : '';
     }
 }


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->
1. See OpenMage/magento-lts#3829

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format OpenMage/magento-lts#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes OpenMage/magento-lts#3828


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. see PR/issue